### PR TITLE
Extend EnItem00 struct, detect when spawned by scene layer

### DIFF
--- a/code/include/z3D/actors/z_en_item00.h
+++ b/code/include/z3D/actors/z_en_item00.h
@@ -34,6 +34,11 @@ typedef enum Item00Type {
     /* 0xFF */ ITEM00_NONE = 0xFF
 } Item00Type;
 
+typedef struct EnItem00Extension {
+    u16 extraCollectibleFlag;
+    u8 spawnedBySceneLayer;
+} EnItem00Extension;
+
 typedef struct EnItem00 {
     /* 0x000 */ Actor actor;
     /* 0x1A4 */ void* action_fn;
@@ -42,6 +47,9 @@ typedef struct EnItem00 {
     /* 0x1AE */ u16 unk_1AE;
     /* 0x1B0 */ u16 unk_1B0;
     /* 0x1B2 */ char unk_1B2[0x66];
-} EnItem00; // size 0x218
+    // end of base game struct
+    /* 0x218 */ EnItem00Extension rExt;
+} EnItem00;
+_Static_assert(offsetof(EnItem00, rExt) == 0x218, "EnItem00 size");
 
 #endif //_EN_ITEM00_H_

--- a/code/src/actor.c
+++ b/code/src/actor.c
@@ -130,10 +130,11 @@ void Actor_Init() {
 
     gActorOverlayTable[0xF].initInfo->update = (ActorFunc)BgYdanSp_rUpdate;
 
-    gActorOverlayTable[0x15].initInfo->init    = EnItem00_rInit;
-    gActorOverlayTable[0x15].initInfo->destroy = EnItem00_rDestroy;
-    gActorOverlayTable[0x15].initInfo->update  = EnItem00_rUpdate;
-    gActorOverlayTable[0x15].initInfo->draw    = EnItem00_rDraw;
+    gActorOverlayTable[0x15].initInfo->init         = EnItem00_rInit;
+    gActorOverlayTable[0x15].initInfo->destroy      = EnItem00_rDestroy;
+    gActorOverlayTable[0x15].initInfo->update       = EnItem00_rUpdate;
+    gActorOverlayTable[0x15].initInfo->draw         = EnItem00_rDraw;
+    gActorOverlayTable[0x15].initInfo->instanceSize = sizeof(EnItem00);
 
     gActorOverlayTable[0x1D].initInfo->update = EnPeehat_rUpdate;
 
@@ -380,6 +381,14 @@ u8 ActorSetup_OverrideEntry(ActorEntry* actorEntry, s32 actorEntryIndex) {
     // Alternate Gold Skulltula Locations
     if (actorEntry->id == 0x95 && (actorEntry->params & 0xE000) && Gs_HasAltLoc(actorEntry, GS_PPT_ACTORENTRY, TRUE)) {
         return TRUE;
+    }
+
+    if (actorEntry->id == ACTOR_EN_ITEM00) {
+        // Mark as spawned by scene layer.
+        // All vanilla actor entries for EnItem00 have Z rotation set to 0,
+        // so we can use it as a custom flag.
+        actorEntry->rot.z = -1;
+        return FALSE;
     }
 
     return Enemizer_OverrideActorEntry(actorEntry, actorEntryIndex);

--- a/code/src/actors/item00.c
+++ b/code/src/actors/item00.c
@@ -58,11 +58,11 @@ void EnItem00_rInit(Actor* thisx, GlobalContext* globalCtx) {
     // For rupees spawned by Rupee Circles (ObjMure3) we use an "extraCollectibleFlag".
     // Since collectibleFlag normally gets truncated to 0x3F we can use any value at or above
     // 0x40. We've reserved 0x40-0x46 for Rupee circle rupees.
-    if (item->collectibleFlag == 0x00 && isObjMure3Updating) {
-        item->rExt.extraCollectibleFlag = extraCollectibleFlag;
-        extraCollectibleFlag += 1;
-        if (extraCollectibleFlag > 0x46) {
-            extraCollectibleFlag = 0x40;
+    if (item->collectibleFlag == 0x00 && gIsObjMure3Updating) {
+        item->rExt.extraCollectibleFlag = gExtraCollectibleFlag;
+        gExtraCollectibleFlag += 1;
+        if (gExtraCollectibleFlag > 0x46) {
+            gExtraCollectibleFlag = 0x40;
         }
     }
     Model_SpawnByActor(&item->actor, globalCtx, 0);

--- a/code/src/actors/item00.c
+++ b/code/src/actors/item00.c
@@ -46,13 +46,20 @@ void EnItem00_rInit(Actor* thisx, GlobalContext* globalCtx) {
             item->actor.params = (item->actor.params & 0xFF00) | 0x00;
         }
     }
+
+    // If Z rotation is -1, it was set in `ActorSetup_OverrideEntry`
+    if (thisx->home.rot.z == -1) {
+        item->rExt.spawnedBySceneLayer = TRUE;
+        thisx->home.rot.z              = 0;
+    }
+
     EnItem00_Init(&item->actor, globalCtx);
 
-    // For rupees spawned by Rupee Circles (ObjMure3) We store the "collectibleFlag" in actor.home.rot.z since that is
-    // not really used for them. Since collectibleFlag normally gets truncated to 0x3F we can use any value at or above
+    // For rupees spawned by Rupee Circles (ObjMure3) we use an "extraCollectibleFlag".
+    // Since collectibleFlag normally gets truncated to 0x3F we can use any value at or above
     // 0x40. We've reserved 0x40-0x46 for Rupee circle rupees.
-    if (item->collectibleFlag == 0x00 && isObjMure3Updating && item->actor.home.rot.z == 0) {
-        item->actor.home.rot.z = extraCollectibleFlag;
+    if (item->collectibleFlag == 0x00 && isObjMure3Updating) {
+        item->rExt.extraCollectibleFlag = extraCollectibleFlag;
         extraCollectibleFlag += 1;
         if (extraCollectibleFlag > 0x46) {
             extraCollectibleFlag = 0x40;

--- a/code/src/actors/obj_mure3.c
+++ b/code/src/actors/obj_mure3.c
@@ -1,13 +1,13 @@
 #include "z3D/z3D.h"
 #include "common.h"
 
-u8 isObjMure3Updating   = 0;    // global variable for rupee circle rupee replacement.
-u8 extraCollectibleFlag = 0x40; // global variable for rupee circle rupee replacement.
+u8 gIsObjMure3Updating   = 0;    // global variable for rupee circle rupee replacement.
+u8 gExtraCollectibleFlag = 0x40; // global variable for rupee circle rupee replacement.
 #define ObjMure3_Update ((ActorFunc)GAME_ADDR(0x002318ac))
 
 void ObjMure3_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
-    extraCollectibleFlag = 0x40;
-    isObjMure3Updating   = TRUE;
+    gExtraCollectibleFlag = 0x40;
+    gIsObjMure3Updating   = TRUE;
     ObjMure3_Update(thisx, globalCtx);
-    isObjMure3Updating = FALSE;
+    gIsObjMure3Updating = FALSE;
 }

--- a/code/src/actors/obj_mure3.h
+++ b/code/src/actors/obj_mure3.h
@@ -2,8 +2,8 @@
 #define _OBJ_MURE3_H_
 
 #include "z3D/z3D.h"
-extern u8 isObjMure3Updating;   // global variable for rupee circle rupee replacement.
-extern u8 extraCollectibleFlag; // global variable for rupee circle rupee replacement.
+extern u8 gIsObjMure3Updating;   // global variable for rupee circle rupee replacement.
+extern u8 gExtraCollectibleFlag; // global variable for rupee circle rupee replacement.
 void ObjMure3_rUpdate(Actor* thisx, GlobalContext* globalCtx);
 
 #endif //_OBJ_MURE3_H_


### PR DESCRIPTION
This fixes the pot issues. As mentioned on Discord, we can detect when a collectible is spawned by the scene in `ActorSetup_OverrideEntry`, to distinguish it from collectibles dropped by pots.

I have added an extension to the Item00 struct where we can add any fields we need, and I moved the `extraCollectibleFlag` there instead of overloading the Z rotation variable.

I also added a `g` prefix to the global variables for clarity.