### PR TITLE
Fix bug with rupee circle

### DIFF
--- a/code/include/z3D/z3D.h
+++ b/code/include/z3D/z3D.h
@@ -811,6 +811,9 @@ typedef u32 (*Flags_GetSwitch_proc)(GlobalContext* globalCtx, u32 flag);
 typedef u32 (*Flags_GetCollectible_proc)(GlobalContext* globalCtx, u32 flag);
 #define Flags_GetCollectible ((Flags_GetCollectible_proc)GAME_ADDR(0x36405C))
 
+typedef u32 (*Flags_SetCollectible_proc)(GlobalContext* globalCtx, u32 flag);
+#define Flags_SetCollectible ((Flags_SetCollectible_proc)GAME_ADDR(0x3329D8))
+
 typedef u32 (*Flags_GetClear_proc)(GlobalContext* globalCtx, u32 flag);
 #define Flags_GetClear ((Flags_GetClear_proc)GAME_ADDR(0x36CF6C))
 

--- a/code/src/item_override.c
+++ b/code/src/item_override.c
@@ -590,7 +590,7 @@ u8 ItemOverride_GetItemDrop(EnItem00* this) {
     if (isMajorItem) {
         ItemOverride_PushPendingOverride(override);
         this->actor.params = ITEM00_HEART_PIECE; // to play no SFX
-        this->actor.parent = &PLAYER->actor;     // to set collection flag
+        Flags_SetCollectible(gGlobalContext, this->collectibleFlag);
         Actor_Kill(&this->actor);
     } else {
         // Minor item, behave as item drop.


### PR DESCRIPTION
This fixes a bug where getting a major item from the cow grotto and then reloading the area causes the rupee circle to not spawn anymore.

I had previously set the rupee parent to make the base game code set the collectible flag, but we can't do that because the spawner actor detects the rupee parent to set a permanent switch flag. So it's better to just set the flag manually.