### PR TITLE
Simpler multiplayer implementation

### DIFF
--- a/code/include/z3D/actors/z_en_item00.h
+++ b/code/include/z3D/actors/z_en_item00.h
@@ -41,7 +41,7 @@ typedef struct EnItem00Extension {
 
 typedef struct EnItem00 {
     /* 0x000 */ Actor actor;
-    /* 0x1A4 */ void* action_fn;
+    /* 0x1A4 */ void* actionFunc;
     /* 0x1A8 */ u16 collectibleFlag;
     /* 0x1AA */ char unk_1AA[0x4];
     /* 0x1AE */ u16 unk_1AE;

--- a/code/src/actors/item00.c
+++ b/code/src/actors/item00.c
@@ -4,6 +4,7 @@
 #include "actors/obj_mure3.h"
 #include "settings.h"
 #include "common.h"
+#include "savefile.h"
 
 #define EnItem00_Init ((ActorFunc)GAME_ADDR(0x1F69B4))
 
@@ -15,7 +16,7 @@
 
 #define THIS ((EnItem00*)thisx)
 
-#define FUN_002B175C (void*)GAME_ADDR(0x2B175C)
+#define EnItem00_Collected ((void*)GAME_ADDR(0x2B175C))
 
 void EnItem00_rInit(Actor* thisx, GlobalContext* globalCtx) {
     EnItem00* item = THIS;
@@ -78,9 +79,16 @@ void EnItem00_rDestroy(Actor* thisx, GlobalContext* globalCtx) {
 void EnItem00_rUpdate(Actor* thisx, GlobalContext* globalCtx) {
     EnItem00* item = THIS;
 
-    if (Flags_GetCollectible(globalCtx, item->collectibleFlag) && item->action_fn != FUN_002B175C) {
-        Actor_Kill(&item->actor);
-        return;
+    if (gSettingsContext.mp_Enabled && item->actionFunc != EnItem00_Collected) {
+        if (Flags_GetCollectible(globalCtx, item->collectibleFlag)) {
+            Actor_Kill(&item->actor);
+            return;
+        }
+
+        u16 flag = item->rExt.extraCollectibleFlag ? item->rExt.extraCollectibleFlag : item->collectibleFlag;
+        if (SaveFile_GetRupeeSanityFlag(globalCtx->sceneNum, flag)) {
+            Model_DestroyByActor(thisx);
+        }
     }
 
     EnItem00_Update(&item->actor, globalCtx);

--- a/code/src/savefile.c
+++ b/code/src/savefile.c
@@ -864,10 +864,10 @@ void SaveFile_OnGameOver(void) {
 
 void SaveFile_SetRupeeSanityFlag(s16 sceneNum, u16 collectibleFlag) {
     if (collectibleFlag >= 0x20 && collectibleFlag < 0x40) {
-        gExtSaveData.rupeesanityFlags[gGlobalContext->sceneNum] |= (1 << (collectibleFlag - 0x20));
+        gExtSaveData.extInf.rupeesanityFlags[sceneNum] |= (1 << (collectibleFlag - 0x20));
     }
     if (collectibleFlag >= 0x40) {
-        gExtSaveData.rupeesanityRupeeCircleFlags[gGlobalContext->sceneNum] |= (1 << (collectibleFlag - 0x40));
+        gExtSaveData.extInf.rupeesanityRupeeCircleFlags[sceneNum] |= (1 << (collectibleFlag - 0x40));
     }
 }
 
@@ -875,13 +875,13 @@ u8 SaveFile_GetRupeeSanityFlag(s16 sceneNum, u16 collectibleFlag) {
     u32 saveFlags;
     u16 shiftBy;
     if (collectibleFlag >= 0x20 && collectibleFlag < 0x40) {
-        saveFlags = gExtSaveData.rupeesanityFlags[sceneNum];
+        saveFlags = gExtSaveData.extInf.rupeesanityFlags[sceneNum];
         shiftBy   = 0x20;
     }
     if (collectibleFlag >= 0x40) {
-        saveFlags = gExtSaveData.rupeesanityRupeeCircleFlags[sceneNum];
+        saveFlags = gExtSaveData.extInf.rupeesanityRupeeCircleFlags[sceneNum];
         shiftBy   = 0x40;
     }
 
-    return ((saveFlags & (1 << (collectibleFlag - shiftBy))) > 0);
+    return (saveFlags & (1 << (collectibleFlag - shiftBy))) != 0;
 }

--- a/code/src/savefile.h
+++ b/code/src/savefile.h
@@ -38,6 +38,8 @@ u8 SaveFile_GetRupeeSanityFlag(s16 sceneNum, u16 collectibleFlag);
 #define EXTSAVEDATA_VERSION 17
 
 typedef struct ExtInf {
+    u32 rupeesanityFlags[SCENE_MAX];
+    u32 rupeesanityRupeeCircleFlags[SCENE_MAX];
     u8 biggoronTrades;
     u8 masterSwordFlags;
     u8 totAltarFlags;
@@ -66,8 +68,6 @@ typedef struct {
     u32 playtimeSeconds;
     u32 scenesDiscovered[SAVEFILE_SCENES_DISCOVERED_IDX_COUNT];
     u32 entrancesDiscovered[SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT];
-    u32 rupeesanityFlags[SCENE_MAX];
-    u32 rupeesanityRupeeCircleFlags[SCENE_MAX];
     u8 hasTimeTraveled;
     u8 permadeath;
     u8 gloomedHeart;


### PR DESCRIPTION
Moving the rupeesanity flags inside the ExtInf struct will have the existing code take care of syncing them when shared progress is enabled.

Then, from `EnItem00_rUpdate`  we can check every frame if the flag is set and destroy the model to revert the rupee to its vanilla appearance. The collection code already checks the flag so there's no need to update it.

This PR is a draft because the first commit should first be PR'd and merged upstream separately. It changes `extInf` from an array to a struct, to make it easier to add new flag variables.