### PR TITLE
Fix multiplayer sync issue

### DIFF
--- a/code/src/multiplayer.c
+++ b/code/src/multiplayer.c
@@ -2151,14 +2151,15 @@ void Multiplayer_Receive_WorldMapBit(u16 senderID) {
     }
 }
 
-void Multiplayer_Send_ExtInfBit(u8 index, u8 bit, u8 setOrUnset) {
+void Multiplayer_Send_ExtInfBit(u16 index, u8 bit, u8 setOrUnset) {
     if (!IsSendReceiveReady() || gSettingsContext.mp_SharedProgress == OFF) {
         return;
     }
     memset(mBuffer, 0, mBufSize);
     u8 memSpacer = PrepareSharedProgressPacket(PACKET_EXTINF);
 
-    mBuffer[memSpacer++] = index;
+    mBuffer[memSpacer] = index;
+    memSpacer += sizeof(index);
     mBuffer[memSpacer++] = bit;
     mBuffer[memSpacer++] = setOrUnset;
     Multiplayer_SendPacket(memSpacer, UDS_BROADCAST_NETWORKNODEID);
@@ -2170,7 +2171,8 @@ void Multiplayer_Receive_ExtInfBit(u16 senderID) {
     }
     u8 memSpacer = GetSharedProgressMemSpacerOffset();
 
-    u8 index      = mBuffer[memSpacer++];
+    u16 index = mBuffer[memSpacer];
+    memSpacer += sizeof(index);
     u8 bit        = mBuffer[memSpacer++];
     u8 setOrUnset = mBuffer[memSpacer++];
 

--- a/code/src/multiplayer.h
+++ b/code/src/multiplayer.h
@@ -52,7 +52,7 @@ void Multiplayer_Send_GSFlagBit(u8 index, u8 bit, u8 setOrUnset);
 void Multiplayer_Send_BigPoePoints(u32 pointDiff);
 void Multiplayer_Send_FishingFlag(u8 bit, u8 setOrUnset);
 void Multiplayer_Send_WorldMapBit(u8 bit, u8 setOrUnset);
-void Multiplayer_Send_ExtInfBit(u8 index, u8 bit, u8 setOrUnset);
+void Multiplayer_Send_ExtInfBit(u16 index, u8 bit, u8 setOrUnset);
 void Multiplayer_Send_TriforcePieces(u32 piecesDiff);
 void Multiplayer_Send_FullEntranceSync(u16 targetID);
 void Multiplayer_Send_DiscoveredScene(u32 index, u32 bit);


### PR DESCRIPTION
The bit index sent during syncing was overflowing because the ExtInf struct now has more than 255 bytes. We can use a u16 for the index to fix this.